### PR TITLE
removed -callback for R14B03|4 compatability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,4 +47,4 @@ build-plt:
 
 dialyze:
 	@$(DIALYZER) --src src --plt .$(PROJECT).plt \
-		-Werror_handling -Wrace_conditions -Wunmatched_returns # -Wunderspecs
+		-Werror_handling -Wno_undefined_callbacks -Wrace_conditions -Wunmatched_returns # -Wunderspecs

--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,8 @@
+{erl_first_files, [
+    "src/ranch_transport.erl"
+]}.
+
 {erl_opts, [
-%%	bin_opt_info,
-%%	warn_missing_spec,
-	warnings_as_errors,
-	warn_export_all
+    warnings_as_errors,
+    warn_export_all
 ]}.

--- a/src/ranch_protocol.erl
+++ b/src/ranch_protocol.erl
@@ -14,11 +14,21 @@
 
 %% @private
 -module(ranch_protocol).
+-export([behaviour_info/1]).
 
 %% Start a new connection process for the given socket.
--callback start_link(
-		ListenerPid::pid(),
-		Socket::any(),
-		Transport::module(),
-		ProtocolOptions::any())
-	-> {ok, ConnectionPid::pid()}.
+%%-callback start_link(
+%%		ListenerPid::pid(),
+%%		Socket::any(),
+%%		Transport::module(),
+%%		ProtocolOptions::any())
+%%	-> {ok, ConnectionPid::pid()}.
+
+
+%% @doc Behaviour information callback.
+behaviour_info(callbacks) ->
+    [{start_link,4}]; %% Start a new connection process for the given socket.
+behaviour_info(_) ->
+    undefined.
+
+

--- a/src/ranch_ssl.erl
+++ b/src/ranch_ssl.erl
@@ -112,8 +112,7 @@ accept(LSocket, Timeout) ->
 %% @private Experimental. Open a connection to the given host and port number.
 %% @see ssl:connect/3
 %% @todo Probably filter Opts?
--spec connect(string(), inet:port_number(), any())
-	-> {ok, inet:socket()} | {error, atom()}.
+-spec connect(string(), inet:port_number(), any()) -> {ok, ssl:sslsocket()} | {error, term()}.
 connect(Host, Port, Opts) when is_list(Host), is_integer(Port) ->
 	ssl:connect(Host, Port,
 		Opts ++ [binary, {active, false}, {packet, raw}]).

--- a/src/ranch_transport.erl
+++ b/src/ranch_transport.erl
@@ -15,16 +15,36 @@
 %% @private
 -module(ranch_transport).
 
+%% Behaviour API
+-export([behaviour_info/1]).
+-export_type([socket/0, opts/0]).
+
+%% @doc Behaviour information callback.
+behaviour_info(callbacks) ->
+    [{name,0},                 %% Name of the transport
+     {messages,0},             %% Atoms used to identify messages in {active, once | true} mode.
+     {listen,1},               %% Listen for connections on the given port number.
+     {accept,2},               %% Accept connections with the given listening socket.
+     {recv, 3},                %% Receive data from a socket in passive mode.
+     {send, 2},                %% Send data on a socket.
+     {setopts, 2},             %% Set options on the given socket.
+     {controlling_process, 2}, %% Give control of the socket to a new process.
+     {peername, 1},            %% Return the remote address and port of the connection.
+     {sockname, 1},            %% Return the local address and port of the connection.
+     {close, 1}];              %% Close the given socket
+behaviour_info(_) ->
+    undefined.
+
 -type socket() :: any().
 -type opts() :: any().
 
-%% Name of the transport.
--callback name() -> atom().
 
-%% @todo -callback caps(secure | sendfile) -> boolean().
+%% Name of the transport.
+%%-callback name() -> atom().
+
 
 %% Atoms used to identify messages in {active, once | true} mode.
--callback messages() -> {OK::atom(), Closed::atom(), Error::atom()}.
+%%-callback messages() -> {OK::atom(), Closed::atom(), Error::atom()}.
 
 %% Listen for connections on the given port number.
 %%
@@ -38,40 +58,40 @@
 %% sockname/1 on the listening socket. If you are using Ranch's
 %% listener API, then this port number can obtained through
 %% ranch:get_port/1 instead.
--callback listen(opts()) -> {ok, socket()} | {error, atom()}.
+%%-callback listen(opts()) -> {ok, socket()} | {error, atom()}.
 
 %% Accept connections with the given listening socket.
--callback accept(socket(), timeout())
-	-> {ok, socket()} | {error, closed | timeout | atom() | tuple()}.
+%%-callback accept(socket(), timeout())
+%%	-> {ok, socket()} | {error, closed | timeout | atom() | tuple()}.
 
 %% Experimental. Open a connection to the given host and port number.
--callback connect(string(), inet:port_number(), opts())
-	-> {ok, socket()} | {error, atom()}.
+%%-callback connect(string(), inet:port_number(), opts())
+%%	-> {ok, socket()} | {error, atom()}.
 
 %% Receive data from a socket in passive mode.
--callback recv(socket(), non_neg_integer(), timeout())
-	-> {ok, any()} | {error, closed | timeout | atom()}.
+%%-callback recv(socket(), non_neg_integer(), timeout())
+%%	-> {ok, any()} | {error, closed | timeout | atom()}.
 
 %% Send data on a socket.
--callback send(socket(), iodata()) -> ok | {error, atom()}.
+%%-callback send(socket(), iodata()) -> ok | {error, atom()}.
 
 %% Set options on the given socket.
--callback setopts(socket(), opts()) -> ok | {error, atom()}.
+%%-callback setopts(socket(), opts()) -> ok | {error, atom()}.
 
 %% Give control of the socket to a new process.
 %%
 %% Must be called from the process currently controlling the socket,
 %% otherwise an {error, not_owner} tuple will be returned.
--callback controlling_process(socket(), pid())
-	-> ok | {error, closed | not_owner | atom()}.
+%%-callback controlling_process(socket(), pid())
+%%	-> ok | {error, closed | not_owner | atom()}.
 
 %% Return the remote address and port of the connection.
--callback peername(socket())
-	-> {ok, {inet:ip_address(), inet:port_number()}} | {error, atom()}.
+%%-callback peername(socket())
+%%	-> {ok, {inet:ip_address(), inet:port_number()}} | {error, atom()}.
 
 %% Return the local address and port of the connection.
--callback sockname(socket())
-	-> {ok, {inet:ip_address(), inet:port_number()}} | {error, atom()}.
+%%-callback sockname(socket())
+%%	-> {ok, {inet:ip_address(), inet:port_number()}} | {error, atom()}.
 
 %% Close the given socket.
--callback close(socket()) -> ok.
+%%-callback close(socket()) -> ok.

--- a/src/ranch_transport.erl
+++ b/src/ranch_transport.erl
@@ -31,6 +31,7 @@ behaviour_info(callbacks) ->
      {controlling_process, 2}, %% Give control of the socket to a new process.
      {peername, 1},            %% Return the remote address and port of the connection.
      {sockname, 1},            %% Return the local address and port of the connection.
+     {connect, 3},             %%  Open a connection to the given host and port number.
      {close, 1}];              %% Close the given socket
 behaviour_info(_) ->
     undefined.


### PR DESCRIPTION
I left the newer code commented out. The only thing I was unsure of is line 115 in ranch_ssl.erl: 

```
-spec connect(string(), inet:port_number(), any()) -> {ok, ssl:sslsocket()} | {error, term()}.
```

`ssl:sslsocket()` is an undefined type.

Also, please advise on what branch this PR should be merged and tagged against.
